### PR TITLE
Make the typing compatible with Python 3.9

### DIFF
--- a/supabase_py_async/__version__.py
+++ b/supabase_py_async/__version__.py
@@ -5,5 +5,4 @@
 @Date Created : 07/01/2024
 @Description  :
 """
-
 __version__ = "2.5.1"

--- a/supabase_py_async/client_async.py
+++ b/supabase_py_async/client_async.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any
+from typing import Any, Optional, Union
 
 from gotrue.types import AuthChangeEvent, Session
 from httpx import Timeout
@@ -31,7 +31,7 @@ class AsyncClient:
         self,
         supabase_url: str,
         supabase_key: str,
-        access_token: str | None = None,
+        access_token: Optional[str] = None,
         options: ClientOptions = ClientOptions(),
     ):
         """Instantiate the client.
@@ -100,7 +100,7 @@ class AsyncClient:
         cls,
         supabase_url: str,
         supabase_key: str,
-        access_token: str | None = None,
+        access_token: Optional[str] = None,
         options: ClientOptions = ClientOptions(),
     ):
         client = cls(supabase_url, supabase_key, access_token, options)
@@ -201,7 +201,7 @@ class AsyncClient:
         rest_url: str,
         headers: dict[str, str],
         schema: str,
-        timeout: int | float | Timeout = DEFAULT_POSTGREST_CLIENT_TIMEOUT,
+        timeout: Union[int, float, Timeout] = DEFAULT_POSTGREST_CLIENT_TIMEOUT,
     ) -> AsyncPostgrestClient:
         """Private helper for creating an instance of the Postgrest client."""
         return AsyncPostgrestClient(
@@ -233,7 +233,7 @@ class AsyncClient:
         }
         self.options.headers.update(**new_headers)
 
-    def _listen_to_auth_events(self, event: AuthChangeEvent, session: Session | None):
+    def _listen_to_auth_events(self, event: AuthChangeEvent, session: Optional[Session]):
         """listen to auth events and update auth token"""
         access_token = self._access_token
         if event in ["SIGNED_IN", "TOKEN_REFRESHED", "SIGNED_OUT"]:
@@ -248,7 +248,7 @@ class AsyncClient:
 async def create_client(
     supabase_url: str,
     supabase_key: str,
-    access_token: str | None = None,
+    access_token: Optional[str] = None,
     options: ClientOptions = ClientOptions(),
 ) -> AsyncClient:
     """Create client function to instantiate supabase client like JS runtime.

--- a/supabase_py_async/lib/auth_client.py
+++ b/supabase_py_async/lib/auth_client.py
@@ -1,3 +1,5 @@
+from typing import Union, Optional, Dict
+
 from gotrue import (
     AsyncGoTrueClient,
     AsyncMemoryStorage,
@@ -14,12 +16,12 @@ class AsyncSupabaseAuthClient(AsyncGoTrueClient):
         self,
         *,
         url: str,
-        headers: dict[str, str] | None = None,
-        storage_key: str | None = None,
+        headers: Optional[Dict[str, str]] = None,
+        storage_key: Optional[str] = None,
         auto_refresh_token: bool = True,
         persist_session: bool = True,
         storage: AsyncSupportedStorage = AsyncMemoryStorage(),
-        http_client: AsyncClient | None = None,
+        http_client: Optional[AsyncClient] = None,
         flow_type: AuthFlowType = "implicit"
     ):
         """Instantiate SupabaseAuthClient instance."""

--- a/supabase_py_async/lib/client_options.py
+++ b/supabase_py_async/lib/client_options.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Optional, Union
 
 # from httpx import Timeout
 from aiohttp import ClientTimeout as Timeout
@@ -32,13 +32,13 @@ class ClientOptions:
     storage: AsyncSupportedStorage = field(default_factory=AsyncMemoryStorage)
     """A storage provider. Used to store the logged in session."""
 
-    realtime: dict[str, Any] | None = None
+    realtime: Optional[dict[str, Any]]= None
     """Options passed to the realtime-py instance"""
 
-    postgrest_client_timeout: int | float | Timeout = DEFAULT_POSTGREST_CLIENT_TIMEOUT
+    postgrest_client_timeout: Union[int, float, Timeout] = DEFAULT_POSTGREST_CLIENT_TIMEOUT
     """Timeout passed to the SyncPostgrestClient instance."""
 
-    storage_client_timeout: int | float | Timeout = DEFAULT_STORAGE_CLIENT_TIMEOUT
+    storage_client_timeout: Union[int, float, Timeout] = DEFAULT_STORAGE_CLIENT_TIMEOUT
     """Timeout passed to the SyncStorageClient instance"""
 
     flow_type: AuthFlowType = "implicit"
@@ -46,17 +46,19 @@ class ClientOptions:
 
     def replace(
         self,
-        schema: str | None = None,
-        headers: dict[str, str] | None = None,
-        auto_refresh_token: bool | None = None,
-        persist_session: bool | None = None,
-        storage: AsyncSupportedStorage | None = None,
-        realtime: dict[str, Any] | None = None,
+        schema: Optional[str] = None,
+        headers: Optional[dict[str, str]] = None,
+        auto_refresh_token: Optional[bool] = None,
+        persist_session: Optional[bool] = None,
+        storage: Optional[AsyncSupportedStorage] = None,
+        realtime: Optional[dict[str, Any]] = None,
         postgrest_client_timeout: (
-            int | float | Timeout
+            Union[int, float, Timeout]
         ) = DEFAULT_POSTGREST_CLIENT_TIMEOUT,
-        storage_client_timeout: int | float | Timeout = DEFAULT_STORAGE_CLIENT_TIMEOUT,
-        flow_type: AuthFlowType | None = None,
+        storage_client_timeout: (
+            Union[int, float, Timeout]
+        ) = DEFAULT_STORAGE_CLIENT_TIMEOUT,
+        flow_type: Optional[AuthFlowType] = None,
     ) -> "ClientOptions":
         """Create a new SupabaseClientOptions with changes"""
         client_options = ClientOptions()


### PR DESCRIPTION
I'm trying to use the library on Vercel and only have Python 3.9 there. These changes make the library compatible by remove the Python 3.10+ typing syntax with the 3.9 syntax.

Thanks so much for the library. Great that it has the auth_token parameter on the create_client() function, couldn't make that work with the original Supabase Python client.

Thank you.